### PR TITLE
fix: GetDataStream must extend Writable, not legacy Stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fs = require('node:fs')
-const { Stream, PassThrough } = require('node:stream')
+const { Stream, PassThrough, Writable } = require('node:stream')
 
 const ChunkEmitter = require('./lib/chunk-emitter')
 const HeaderSkipper = require('./lib/header-skipper')
@@ -302,26 +302,22 @@ class MessageStream extends Stream {
 
 module.exports = MessageStream
 
-class GetDataStream extends Stream {
+class GetDataStream extends Writable {
   constructor(cb) {
     super()
     this.cb = cb
-    this.buf = Buffer.alloc(0)
-    this.writable = true
+    this.chunks = []
   }
 
-  write(obj) {
-    this.buf = Buffer.concat([this.buf, obj])
-    return true
+  _write(chunk, _enc, done) {
+    this.chunks.push(chunk)
+    done()
   }
 
-  end(obj) {
-    if (obj) this.buf = Buffer.concat([this.buf, obj])
-    this.cb(this.buf)
+  _final(done) {
+    this.cb(Buffer.concat(this.chunks))
+    done()
   }
-
-  destroy() {} // ignore
-  destroySoon() {} // ignore
 }
 
 module.exports.ChunkEmitter = ChunkEmitter

--- a/test/functional.js
+++ b/test/functional.js
@@ -316,6 +316,48 @@ describe('MessageStream Functional Tests', () => {
     ms.destroy()
   })
 
+  it('get_data() returns full body for spooled messages with ctor headers', async () => {
+    const cfg = {
+      main: {
+        spool_after: 5 * 1024 * 1024, // 5 MB, matches realistic production
+        spool_dir: TMP_DIR,
+      },
+    }
+    // Pass header_list like Haraka's transaction.js does
+    const headers = ['From: a@example.com\r\n', 'To: b@example.com\r\n']
+    const ms = new MessageStream(cfg, 'test-get-data-spool-hdrs', headers)
+
+    // Feed headers + large body
+    ms.add_line('From: a@example.com\r\n')
+    ms.add_line('To: b@example.com\r\n')
+    ms.add_line('\r\n')
+    // 6 MB of 76-character base64-like lines (realistic attachment shape)
+    const line = 'A'.repeat(76) + '\r\n'
+    const linesNeeded = Math.ceil((6 * 1024 * 1024) / line.length)
+    for (let i = 0; i < linesNeeded; i++) {
+      ms.add_line(line)
+    }
+
+    await new Promise((resolve) => ms.add_line_end(resolve))
+    assert.strictEqual(ms.spooling, true, 'message should have been spooled')
+
+    const buffer = await new Promise((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error('get_data callback never fired')),
+        3000,
+      )
+      ms.get_data((data) => {
+        clearTimeout(timeout)
+        resolve(data)
+      })
+    })
+
+    assert.ok(buffer.length > 5 * 1024 * 1024, 'should return full body')
+    const str = buffer.toString('utf8', 0, 200)
+    assert.ok(str.includes('From: a@example.com'), 'should contain headers')
+    ms.destroy()
+  })
+
   it('emits error if spool directory does not exist', async () => {
     const cfg = {
       main: {


### PR DESCRIPTION
fixes #18 

## Summary

`MessageStream.get_data(cb)` hangs forever on spooled messages when the constructor is passed a non-empty `headers` array. No `'error'` event fires; the only symptom is that `cb` is never invoked, so any plugin reading the full body from `data_post` hits Haraka's `plugin_timeout` and DENYSOFTs the message.

## Test coverage

Added one regression test: `get_data() returns full body for spooled messages with ctor headers`. It:

1. Creates a `MessageStream` with `spool_after = 5 MB` and a non-empty `headers` array (mimicking Haraka transactions).
2. Writes ~6 MB of body — large enough to spool and to fill internal highWaterMarks.
3. Calls `get_data(cb)` with a 3s timeout.
4. Asserts the callback fires with the full body.

Without this fix, the test times out after 3s with `get_data callback never fired`. With the fix it completes in ~70 ms.

## Minimal repro

```js
const MessageStream = require('haraka-message-stream')

const ms = new MessageStream(
  { main: { spool_after: 5 * 1024 * 1024, spool_dir: '/tmp' } },
  'repro',
  ['From: a@example.com\r\n'], // ctor headers is the trigger
)

ms.add_line('From: a@example.com\r\n')
ms.add_line('\r\n')
for (let i = 0; i < 100000; i++) ms.add_line('A'.repeat(76) + '\r\n')

ms.add_line_end(() => {
  console.log('spooling=', ms.spooling) // true
  const timeout = setTimeout(() => {
    console.log('❌ get_data never fired')
    process.exit(2)
  }, 5000)
  ms.get_data((buf) => {
    clearTimeout(timeout)
    console.log('✅ get_data fired, bytes=', buf.length)
    process.exit(0)
  })
})
```

Without the fix: prints `❌ get_data never fired` after 5 s.
With the fix: prints `✅ get_data fired, bytes=7600000` after ~40 ms.